### PR TITLE
fix: target branch

### DIFF
--- a/.github/workflows/deliver-icons-to-spark.yml
+++ b/.github/workflows/deliver-icons-to-spark.yml
@@ -23,5 +23,5 @@ jobs:
           destination-repository-name: "spark"
           user-email: ${{ secrets.API_GITHUB_COMMIT_EMAIL }}
           commit-message: See ORIGIN_COMMIT from $GITHUB_REF
-          target-branch: chore-updated-icons
+          create-target-branch-if-needed: chore-updated-icons
           target-directory: "packages/components/icons/assets"


### PR DESCRIPTION
This PR enables the GitHub action to create a target branch if it doesn't exist on Spark Web.