### PR TITLE
chore: add icon clean-up script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tokens/*
 !tokens/spark
 .idea
 .DS_Store
+temp-icons/

--- a/helpers/actions/assets/utils/cleanUpSVGIcons.js
+++ b/helpers/actions/assets/utils/cleanUpSVGIcons.js
@@ -24,15 +24,21 @@ function cleanSVG(inputPath, outputPath) {
       const viewBox = result.svg.$.viewBox || "0 0 24 24";
       let paths = result.svg.path || [];
 
-      if (
-        result.svg.g &&
-        result.svg.g[0].$ &&
-        result.svg.g[0].$["clip-path"] &&
-        result.svg.g[0].path
-      ) {
-        const pathInsideGroup = result.svg.g[0].path[0];
-        if (pathInsideGroup.$ && pathInsideGroup.$.d) {
-          paths = [{ $: { d: pathInsideGroup.$.d } }];
+      if (result.svg.g) {
+        const groupedPaths = result.svg.g.filter((group) => group.path);
+
+        if (groupedPaths.length === 1) {
+          const pathsInsideGroup = groupedPaths[0].path;
+          pathsInsideGroup.forEach((pathInsideGroup) => {
+            if (pathInsideGroup.$ && pathInsideGroup.$.d) {
+              paths.push({
+                $: {
+                  d: pathInsideGroup.$.d,
+                  "fill-rule": pathInsideGroup.$["fill-rule"],
+                },
+              });
+            }
+          });
         }
       }
 
@@ -87,10 +93,7 @@ function cleanSVGsInInputDirectory(inputFolder, outputFolder) {
       const outputPath = path.join(outputFolder, file);
 
       if (path.extname(inputPath).toLowerCase() === ".svg") {
-        const existingOutputPath = path.join(outputFolder, file);
-        if (fs.existsSync(existingOutputPath)) {
-          cleanSVG(inputPath, existingOutputPath);
-        }
+        cleanSVG(inputPath, outputPath);
       }
     });
   });

--- a/helpers/actions/assets/utils/cleanUpSVGIcons.js
+++ b/helpers/actions/assets/utils/cleanUpSVGIcons.js
@@ -1,0 +1,101 @@
+const fs = require("fs");
+const path = require("path");
+const xml2js = require("xml2js");
+const parseString = xml2js.parseString;
+
+function cleanSVG(inputPath, outputPath) {
+  fs.readFile(inputPath, "utf8", (err, data) => {
+    if (err) {
+      console.error(`Icons - Error reading file ${inputPath}: ${err}`);
+      return;
+    }
+
+    parseString(data, (err, result) => {
+      if (err) {
+        console.error(`Icons - Error parsing SVG: ${err}`);
+        return;
+      }
+
+      if (!result.svg) {
+        console.error(`Icons - Invalid SVG format in ${inputPath}`);
+        return;
+      }
+
+      const viewBox = result.svg.$.viewBox || "0 0 24 24";
+      let paths = result.svg.path || [];
+
+      if (
+        result.svg.g &&
+        result.svg.g[0].$ &&
+        result.svg.g[0].$["clip-path"] &&
+        result.svg.g[0].path
+      ) {
+        const pathInsideGroup = result.svg.g[0].path[0];
+        if (pathInsideGroup.$ && pathInsideGroup.$.d) {
+          paths = [{ $: { d: pathInsideGroup.$.d } }];
+        }
+      }
+
+      const newPaths = paths
+        .filter((pathElement) => !pathElement.mask)
+        .map((pathElement) => {
+          const newPath = { $: {} };
+          if (pathElement.$["fill-rule"]) {
+            newPath.$["fill-rule"] = pathElement.$["fill-rule"];
+          }
+          newPath.$.d = pathElement.$.d;
+          return newPath;
+        });
+
+      const newSVG = {
+        svg: {
+          $: {
+            viewBox,
+            xmlns: "http://www.w3.org/2000/svg",
+          },
+          path: newPaths,
+        },
+      };
+
+      const builder = new xml2js.Builder();
+      const cleanData = builder
+        .buildObject(newSVG)
+        .replace(/<\?xml.*\?>\n/, "");
+
+      fs.writeFile(outputPath, cleanData, "utf8", (err) => {
+        if (err) {
+          console.error(
+            `Icons - Error writing cleaned SVG to ${outputPath}: ${err}`
+          );
+          return;
+        }
+        console.log(`Icons - Cleaned SVG saved to ${outputPath}`);
+      });
+    });
+  });
+}
+
+function cleanSVGsInInputDirectory(inputFolder, outputFolder) {
+  fs.readdir(inputFolder, (err, files) => {
+    if (err) {
+      console.error(`Icons - Error reading directory ${inputFolder}: ${err}`);
+      return;
+    }
+
+    files.forEach((file) => {
+      const inputPath = path.join(inputFolder, file);
+      const outputPath = path.join(outputFolder, file);
+
+      if (path.extname(inputPath).toLowerCase() === ".svg") {
+        const existingOutputPath = path.join(outputFolder, file);
+        if (fs.existsSync(existingOutputPath)) {
+          cleanSVG(inputPath, existingOutputPath);
+        }
+      }
+    });
+  });
+}
+
+module.exports = {
+  cleanSVGsInInputDirectory,
+};

--- a/helpers/actions/assets/utils/generatePaths.js
+++ b/helpers/actions/assets/utils/generatePaths.js
@@ -1,13 +1,21 @@
 const fs = require("fs");
 const path = require("path");
 
+// Load clean up script
+const cleanUpScript = require("./cleanUpSVGIcons");
+
 // Load checkers
 const iconNamingValidator = require("./iconNamingValidator");
 const svgDuplicateChecker = require("./SVGDuplicateChecker");
 
 // Read brand folder
 const brand = process.argv[2] || "spark";
-const assetDir = `./assets/${brand}/icons`;
+const brandAssetsDir = `./assets/${brand}/`;
+const assetDir = `${brandAssetsDir}/icons`;
+const tempAssetDir = `${brandAssetsDir}/temp-icons`;
+
+// Execute the clean up script on new icons
+cleanUpScript.cleanSVGsInInputDirectory(tempAssetDir, assetDir);
 
 const asset = {};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "sharp": "^0.31.3",
         "style-dictionary": "^3.7.2",
         "svg2vectordrawable": "^2.9.1",
+        "svgo": "^3.0.2",
         "xml2js": "^0.6.2"
       }
     },
@@ -453,6 +454,35 @@
         "upper-case": "^2.0.2"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -464,6 +494,39 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "dev": true,
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "dev": true
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
@@ -507,6 +570,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
     "node_modules/domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -518,6 +595,35 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dev": true,
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -542,6 +648,18 @@
       "dev": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -884,6 +1002,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
@@ -1373,6 +1497,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -1642,6 +1775,39 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
+      "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
+      "dev": true,
+      "dependencies": {
+        "@trysound/sax": "0.2.0",
+        "commander": "^7.2.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^2.2.1",
+        "csso": "^5.0.5",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/svgpath": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@divriots/style-dictionary-to-figma": "^0.4.0",
         "change-case": "^4.1.2",
         "chokidar-cli": "^3.0.0",
         "chroma-js": "^2.4.2",
@@ -18,14 +17,8 @@
         "sharp": "^0.31.3",
         "style-dictionary": "^3.7.2",
         "svg2vectordrawable": "^2.9.1",
-        "svgo": "^3.0.2"
+        "xml2js": "^0.6.2"
       }
-    },
-    "node_modules/@divriots/style-dictionary-to-figma": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@divriots/style-dictionary-to-figma/-/style-dictionary-to-figma-0.4.0.tgz",
-      "integrity": "sha512-vSC3u1xBi9ShYpGEP+atS+L0vnNnSFmjtvB976+yNUT25nvgpUYCb1ZsSpKBe8+Uk1Qww+4ZIK+/91k3msfs2Q==",
-      "dev": true
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
@@ -460,35 +453,6 @@
         "upper-case": "^2.0.2"
       }
     },
-    "node_modules/css-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-      "dev": true,
-      "dependencies": {
-        "mdn-data": "2.0.30",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
     "node_modules/css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -500,39 +464,6 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
-    },
-    "node_modules/csso": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
-      "dev": true,
-      "dependencies": {
-        "css-tree": "~2.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/css-tree": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-      "dev": true,
-      "dependencies": {
-        "mdn-data": "2.0.28",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/mdn-data": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-      "dev": true
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
@@ -576,20 +507,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
     "node_modules/domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -601,35 +518,6 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ]
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-      "dev": true,
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -654,18 +542,6 @@
       "dev": true,
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1008,12 +884,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-      "dev": true
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
@@ -1369,10 +1239,16 @@
         }
       ]
     },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1492,15 +1368,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1777,39 +1644,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/svgo": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
-      "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
-      "dev": true,
-      "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^5.1.0",
-        "css-tree": "^2.2.1",
-        "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/svgo"
-      }
-    },
-    "node_modules/svgo/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/svgpath": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.6.0.tgz",
@@ -1968,6 +1802,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/y18n": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "sharp": "^0.31.3",
     "style-dictionary": "^3.7.2",
     "svg2vectordrawable": "^2.9.1",
-    "svgo": "^3.0.2"
+    "xml2js": "^0.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "sharp": "^0.31.3",
     "style-dictionary": "^3.7.2",
     "svg2vectordrawable": "^2.9.1",
+    "svgo": "^3.0.2",
     "xml2js": "^0.6.2"
   }
 }


### PR DESCRIPTION
Following the recent quality audit on icons, this pull request addresses several key issues identified and introduces an improved icon clean-up script to enhance the quality and compatibility of icons.

Key Improvements:

- Icon Size Standardization: Icons that were not exportable unless exactly 24x24 px have been meticulously addressed. The new script ensures that all icons adhere to this size requirement.
- Mask Removal: To ensure compatibility with iOS platforms, icons containing masks have been thoroughly reviewed and corrected. The new script adeptly eliminates any masks present.
- Simplified Attributes: Unwanted fill colors, groups, and clip-path attributes that might have introduced unnecessary complexity to icons have been efficiently eliminated. The new script retains only the essential path and fill-rule attributes.
- Uniform Top Definition: Inconsistencies in the `<svg>` top definition across various icons have been resolved using the new script. This guarantees a standardized and uniform top definition for all icons.

This pull request represents a significant step forward in maintaining a high standard of quality across our icon collection.