### PR TITLE
chore: Update icon delivery destination repository

### DIFF
--- a/.github/workflows/deliver-icons-to-spark-web.yml
+++ b/.github/workflows/deliver-icons-to-spark-web.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           source-directory: build/web/dist/spark/icons
           destination-github-username: "adevinta"
-          destination-repository-name: "spark"
+          destination-repository-name: "polaris-web-icons"
           user-email: ${{ secrets.API_GITHUB_COMMIT_EMAIL }}
           commit-message: |
             chore(icons): update icons


### PR DESCRIPTION
The destination repository for icons delivery in the GitHub workflow has been changed. Previously, icons were being delivered to the "spark" repository. Now, they will be delivered to the "polaris-web-icons" repository.

☝️ this message is made by [Jetbrains-AI](https://www.jetbrains.com/ai/)